### PR TITLE
MON-69-WhenBossGetsHit

### DIFF
--- a/Assets/KDY/BossScene.unity
+++ b/Assets/KDY/BossScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18380341, g: 0.22842261, b: 0.30008942, a: 1}
+  m_IndirectSpecularColor: {r: 0.18380311, g: 0.22842214, b: 0.3000882, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -347,12 +347,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!95 &311204399 stripped
-Animator:
-  m_CorrespondingSourceObject: {fileID: 7197882686852157380, guid: e95bb50e515ecf24bb97c543ec22416d,
-    type: 3}
-  m_PrefabInstance: {fileID: 907181306}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &361080603
 GameObject:
   m_ObjectHideFlags: 0
@@ -481,7 +475,7 @@ Transform:
   m_GameObject: {fileID: 361080603}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4.09, y: 0.5, z: 14.07}
+  m_LocalPosition: {x: 0, y: 0.5, z: 15}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2022,7 +2016,7 @@ CapsuleCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
@@ -2077,7 +2071,7 @@ CapsuleCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
@@ -2345,11 +2339,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 668cdace8166210438a529efa22b6874, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  movementSpeed: 7
+  moveSpeed: 10
+  rotationSpeed: 200
   player: {fileID: 361080608}
-  bossRb: {fileID: 1478099715}
-  animator: {fileID: 311204399}
-  rotationToPlayer: 0
+  isBossGetHit: 0
+  isBossDead: 0
 --- !u!65 &1478099714
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/KDY/Scripts/CombatManager.cs
+++ b/Assets/KDY/Scripts/CombatManager.cs
@@ -20,6 +20,8 @@ public class CombatManager : MonoBehaviour
     public static bool _isPlayerInRange;
     public static bool _isPlayerInBossView;
 
+    public static bool _bossGetHit;
+
     void Awake()
     {
         if (_instance != null)
@@ -77,7 +79,11 @@ public class CombatManager : MonoBehaviour
         if (type == "Player")
             _currentBossHP -= damage;
         if (type == "Boss")
+        {
             _currentPlayerHP -= damage;
+            _bossGetHit = !_bossGetHit;
+            _bossGetHit = !_bossGetHit;
+        }
     }
 
 }


### PR DESCRIPTION
1. 보스가 데미지를 입었을 경우, Hit 모션을 출력합니다.
2. 데미지를 입는 방식은 추후 개발해야 할 것 같아 현재는 bool 형식으로 입력을 true로 받으면 출력하게 하였습니다.
3. isBossGetHit, isBossDead 각각 데미지를 입었을 경우, 보스의 HP가 0일 경우로 BossBT.cs 파일에서 확인할 수 있습니다.
4. 보스의 회전 방식을 Rigidbody기반으로 변경하였습니다. BossBT.cs의 LookAtPlayer()에서 확인할 수 있습니다.
5. 이에 따라 전투 상태에서 플레이어를 한 번 트래킹 하면 영원히 따라다니게 되었는데 이 부분은 추후 기능 구현 단계에서 보완하도록 하겠습니다.
6. BossBT.cs에서 게임엔진 상에 드러나도 되지 않아도 되는 값은 private 처리하였습니다.