### PR TITLE
MON-85-BossTrackedPlayer

### DIFF
--- a/Assets/Scenes/Boss/BossScene.unity
+++ b/Assets/Scenes/Boss/BossScene.unity
@@ -342,7 +342,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 5, y: 1, z: 5}
+  m_LocalScale: {x: 9, y: 1, z: 9}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -475,7 +475,7 @@ Transform:
   m_GameObject: {fileID: 361080603}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.5, z: 14.07}
+  m_LocalPosition: {x: 1.1, y: 0.5, z: 4.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1051,8 +1051,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1476849647}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.11181193, y: 0.88495857, z: -0.27696222, w: -0.35726526}
-  m_LocalPosition: {x: 14.111963, y: 8.5027895, z: 14.051155}
+  m_LocalRotation: {x: -0.18856241, y: 0.8064004, z: -0.3431503, w: -0.4431821}
+  m_LocalPosition: {x: 32.07954, y: 23.600086, z: 14.069101}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/Boss/BossBT.cs
+++ b/Assets/Scripts/Boss/BossBT.cs
@@ -2,6 +2,7 @@ using CleverCrow.Fluid.BTs.Trees;
 using CleverCrow.Fluid.BTs.Tasks;
 using System.Collections;
 using UnityEngine;
+using Unity.VisualScripting;
 
 public class BossBT : MonoBehaviour
 {
@@ -25,6 +26,9 @@ public class BossBT : MonoBehaviour
     // 프로토타입 진행을 위한 임시 변수
     public bool isBossGetHit = false;
     public bool isBossDead = false;
+    public bool _detectedPlayer = false;
+    public bool _trackingPlayer = false;
+    public float _perceptionTime = 0;
 
     private void Awake()
     {
@@ -36,7 +40,11 @@ public class BossBT : MonoBehaviour
             .Selector()
                 // Left SubTree
                 .Sequence()
-                    .Condition("isPlayerInAttackRange", () => CombatManager._isPlayerInRange)
+                    .Condition("isPlayerInAttackRange", () => CombatManager._bossAttackRange)
+                        .Do(() => 
+                        { 
+                            return TaskStatus.Success;
+                        })
                         .Selector()
 /*                            .Sequence()
                                 .Condition("canBreathAttack", () => _canBreathAttack = SetBreathChance())
@@ -54,11 +62,10 @@ public class BossBT : MonoBehaviour
                                     _canBreathAttack = !_canBreathAttack;
                                     return TaskStatus.Success;
                                 })
-                            .End()
-*/                            .StateAction("NomalAttack", () =>
+                            .End()*/
+                            .StateAction("NomalAttack", () =>
                             {
-                                _bossRb.velocity = Vector3.zero;
-                                _rotationToPlayer = false;
+                                _trackingPlayer = false;
                             })
                             .Do(() =>
                             {
@@ -68,24 +75,27 @@ public class BossBT : MonoBehaviour
                         .End()
                 .End()
 
-                // Middle SubTree
+                // Midle SubTree
                 .Sequence()
-                    .Condition("detectedPlayer", () => CombatManager._isPlayerInBossView )
-                    .StateAction("BattleTracking", () =>
-                    {
-                        _rotationToPlayer = true;
-                        _startTracking = true;
-                    })
-                    .Do("TrackingPlayer", () =>
-                    {
-                        Debug.Log("BattleTracking");
-                        return TaskStatus.Success;
-                    })
+                    .Condition("TrackingPlayer", () => _detectedPlayer)
+                        .StateAction("BattleTracking", () =>
+                        {
+                            isBossGetHit = false;
+                            _trackingPlayer = true;
+                        })
+                        .Do("TrackingPlayer", () =>
+                        {
+                            Debug.Log("TrackingPlayer");
+                            return TaskStatus.Success;
+                        })
                 .End()
 
                 // Right SubTree
                 .Sequence()
-                    .StateAction("NomalWalking", () => _rotationToPlayer = false )
+                    .StateAction("NomalWalking", () => 
+                    {
+                        //_trackingPlayer = false;
+                    })
                     .Do("NomalWalking", () =>
                     {
                         Debug.Log("NomalWalking");
@@ -101,19 +111,43 @@ public class BossBT : MonoBehaviour
         CombatManager.isPlayerInRange(_player, gameObject.transform);
         _wayToGoPlayer.y = 0;
 
-        if (_rotationToPlayer)
+        if (CombatManager._bossAttackBackRange && CombatManager._isbossRecognizedPlayer)
         {
-            LookAtPlayer();
+            _detectedPlayer = true;
         }
 
-        if (_startTracking)
+        if (CombatManager._bossVisualRange)
         {
+            _detectedPlayer = true;
+        }
+
+        if (_trackingPlayer)
+        {
+            LookAtPlayer();
             TrackingPlayer();
+
+            if(!CombatManager._bossVisualRange || !CombatManager._bossPerceptionRange)
+            {
+                _perceptionTime += Time.deltaTime;
+            }
+        }
+
+        if(_perceptionTime >= 3)
+        {
+            _trackingPlayer = false;
+            _detectedPlayer = false;
+            CombatManager._isbossRecognizedPlayer = false;
+            _perceptionTime = 0;
         }
 
     }
 
     private void Start() { ActivateAi(); }
+
+    public void ActivateAi()
+    {
+        StartCoroutine(ActivateAiCo());
+    }
 
     IEnumerator ActivateAiCo()
     {
@@ -122,6 +156,9 @@ public class BossBT : MonoBehaviour
             if (isBossGetHit)   // 추후 CombatManager._bossGetHit로 변경 예정
             {
                 _animator.Play("Hit");
+                CombatManager._bossGetHit = false;
+                CombatManager._isbossRecognizedPlayer = true;   // 임시로 넣어 둠. 추후 플레이어와의 상호작용에서 제거 예정
+                _detectedPlayer = true;
             }
 
             if (isBossDead)   // 추후 !CombatManager._isBossDead로 변경 예정
@@ -139,36 +176,29 @@ public class BossBT : MonoBehaviour
         }
     }
 
-    public void ActivateAi()
-    {
-        StartCoroutine(ActivateAiCo());
-    }
-
+    /// <summary>
+    /// 플레이어를 트래킹합니다. 
+    /// </summary>
     private void TrackingPlayer()
     {
-        if (!CombatManager._isPlayerInRange)
-        {
-            Vector3 direction = (_player.position - transform.position).normalized;
-            _moveDirection = new Vector3(direction.x, 0, direction.z); // y축 방향은 무시
-            _bossRb.MovePosition(transform.position + _moveDirection * _moveSpeed * Time.fixedDeltaTime);
-        }
+        Vector3 direction = (_player.position - transform.position).normalized;
+        _moveDirection = new Vector3(direction.x, 0, direction.z); // y축 방향은 무시
+        _bossRb.MovePosition(transform.position + _moveDirection * _moveSpeed * Time.fixedDeltaTime);
     }
 
+    /// <summary>
+    /// 플레이어로 몸을 향합니다.
+    /// </summary>
     public void LookAtPlayer()
     {
-        Vector3 targetDirection = (_player.position - transform.position).normalized;
-
-        if (targetDirection != Vector3.zero)
-        {
-            Quaternion targetRotation = Quaternion.LookRotation(_moveDirection);
-            Quaternion rotation = Quaternion.RotateTowards(transform.rotation, targetRotation, _rotationSpeed * Time.fixedDeltaTime);
-            _bossRb.MoveRotation(rotation);
-        }
+        Quaternion targetRotation = Quaternion.LookRotation(_moveDirection);
+        Quaternion rotation = Quaternion.RotateTowards(transform.rotation, targetRotation, _rotationSpeed * Time.fixedDeltaTime);
+        _bossRb.MoveRotation(rotation);
     }
 
     public bool SetBreathChance()
     {
-        float ran = UnityEngine.Random.value;
+        float ran = Random.value;
         if(ran <= 0.5) return _canBreathAttack = true;   // 추후 boss HP 가 30% 이하일 조건 추가 : CombatManager._currentBossHP <= 600 && 
         else return _canBreathAttack = false;
     }
@@ -178,7 +208,7 @@ public class BossBT : MonoBehaviour
         if (gameObject.transform != null)
         {
             // 플레이어가 범위 내에 있을 때 빨간색으로, 아니면 녹색으로 범위를 표시
-            Gizmos.color = CombatManager._isPlayerInRange ? Color.red : Color.green;
+            Gizmos.color = CombatManager._bossAttackRange ? Color.red : Color.green;
             Gizmos.DrawWireSphere(gameObject.transform.position, 9f);
 
             // 보스의 시야 범위를 파란색으로 표시
@@ -189,6 +219,22 @@ public class BossBT : MonoBehaviour
             Gizmos.color = Color.yellow;
             Gizmos.DrawLine(gameObject.transform.position, gameObject.transform.position + gameObject.transform.forward * 18f);
         }
+    }
+
+    /// <summary>
+    /// 어떠한 애니메이션 후에 울부짖는 애니메이션을 출력할 수 있는 코루틴 실행 함수입니다.
+    /// Hit의 경우 0.8초가 알맞습니다.
+    /// </summary>
+    /// <param name="time">이전 애니메이션이 실행되고 있는 시간</param>
+    private void Roaring(float time)
+    {
+        StartCoroutine(CoRoar(time));
+    }
+
+    private IEnumerator CoRoar(float time)
+    {
+        yield return new WaitForSeconds(time);
+        _animator.Play("Roar");
     }
 
     /*    public void BossSound(string name)

--- a/Assets/Scripts/Boss/CombatManager.cs
+++ b/Assets/Scripts/Boss/CombatManager.cs
@@ -18,8 +18,11 @@ public class CombatManager : MonoBehaviour
     public static bool _isBossDead { get; set; } = false;
 
     public static float distancePtoB;
-    public static bool _isPlayerInRange;
-    public static bool _isPlayerInBossView;
+    public static bool _bossAttackRange;
+    public static bool _bossAttackBackRange;
+    public static bool _bossVisualRange;
+    public static bool _bossPerceptionRange;
+    public static bool _isbossRecognizedPlayer;
 
     public static bool _bossGetHit;
 
@@ -62,14 +65,32 @@ public class CombatManager : MonoBehaviour
         Vector3 normalized = (player.position - boss.position).normalized;
         float _isForward = Vector3.Dot(normalized, boss.forward);
 
+        // 공격 범위
         if (_isForward > 0 && distancePtoB <= 9f)
         {
-            _isPlayerInRange = true;
+            _bossAttackRange = true;
+            _bossAttackBackRange = false;
+            _isbossRecognizedPlayer = true;
         }
-        else _isPlayerInRange = false;
+        else if (_isForward < 0 && distancePtoB <= 9f)
+        {
+            _bossAttackRange = false;
+            _bossAttackBackRange = true;
+            _isbossRecognizedPlayer = true;
+        }
+        else
+        {
+            _bossAttackRange = false;
+            _bossAttackBackRange = false;
+        }
 
-        if (_isForward > 0 && distancePtoB <= 18f) _isPlayerInBossView = true;
-        else _isPlayerInBossView = false;
+        // 시야 범위
+        if (_isForward > 0 && distancePtoB <= 18f) _bossVisualRange = true;
+        else _bossVisualRange = false;
+
+        //인식 범위
+        if (distancePtoB <= 18f) _bossPerceptionRange = true;
+        else _bossPerceptionRange = false;
     }
 
 
@@ -82,14 +103,17 @@ public class CombatManager : MonoBehaviour
     {
         if (type == "Player")
             _currentBossHP -= damage;
+            _isbossRecognizedPlayer = true;
         if (type == "Boss")
         {
             _currentPlayerHP -= damage;
-            _bossGetHit = !_bossGetHit;
-            _bossGetHit = !_bossGetHit;
+            _bossGetHit = true;
+            _bossGetHit = false;
         }
     }
 
+
+    //////////////////////////////////////////////////////////////////////////
     public void StartBreathAttack()
     {
         StartCoroutine(BreathAttack()); 

--- a/Assets/Scripts/Boss/NomalAttackTrigger.cs
+++ b/Assets/Scripts/Boss/NomalAttackTrigger.cs
@@ -27,6 +27,10 @@ public class NomalAttackTrigger : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// NomalAttack을 한 번 실행하는 동안 공격이 중첩되지 않도록 
+    /// _isNomalAttacking를 잠시 켰다 꺼는 코루틴 CoNomalAttack을 실행합니다.
+    /// </summary>
     public void NowNomalAttacking()
     {
         StartCoroutine(CoNomalAttack());
@@ -40,6 +44,12 @@ public class NomalAttackTrigger : MonoBehaviour
         _isNomalAttacking = false;
     }
 
+    /// <summary>
+    /// boss의 nomalAttack에 충돌된 위치에 HitEffect를 나타내는 코루틴을 실행합니다.
+    /// 해당 코루틴은 CoHitEffect입니다.
+    /// </summary>
+    /// <param name="hitPos">플레이어가 보스에게 맞은 곳</param>
+    /// <param name="player">충돌된 개체 = Player</param>
     public void AppearHitEffect(Vector3 hitPos, GameObject player)
     {
         StartCoroutine(CoHitEffect(hitPos, player));


### PR DESCRIPTION
## 설명

1. 보스가 플레이어를 인식하고 트래킹하는 코드를 작성하였습니다. 해당 기능은 CombatManager.cs 와 Boss.cs를 보완하여 완성되었습니다.

2. 이전까지 공격 범위와 시야 범위만 설정해놓았는데, 이에 따른 AI상 허점이 많이 보여서 보스의 감지 범위를 인지 범위까지 추가 후 변수를 수정 및 추가하고, 코드를 보완하였습니다.

3. CombatManager 클래스에 선언된 변수명을 일부 수정하고 일부 상태를 변수로 추가하였습니다.

4. 보스가 플레이어를 인식할 만한 상황을 구체화하였습니다. 4-1. 플레이어가 시야에 있을 때
4-2. 플레이어에게 데미지를 입었을 때

5. 보스가 플레이어를 인식하고 있을 때의 임시 변수 추가

6. BossBT 클래스의 MidTree 조건 변경하였습니다. 이에 따라 해당 조건들을 Update() 에서 지속적으로 보스가 플레이어를 트래킹하는 조건에 부합하는지 체크하게 하였습니다. 6-1. 플레이어가 보스의 공격 범위 바로 뒤에 있고 보스는 그것을 인지하고 있는가
6-2. 플레이어가 시야에 있는가
6-3. 보스가 플레이어로 향하는 두 함수를 변수 _trackingPlayer로 조작하게 하였습니다.

7. Nomal상태로 돌아가는 조건을 인식 범위를 벗어나 일정 시간이 지나면 돌아가도록 하였습니다.