### PR TITLE
MON-129-AttackCollision

### DIFF
--- a/Assets/Animations/Player/2Handed@Attack1_S.FBX.meta
+++ b/Assets/Animations/Player/2Handed@Attack1_S.FBX.meta
@@ -551,8 +551,16 @@ ModelImporter:
         floatParameter: 0
         intParameter: 0
         messageOptions: 0
-      - time: 0.46407187
-        functionName: AttackTrigger
+      - time: 0.44873598
+        functionName: AttackRangeCollierTurnOn
+        data: 
+        objectReferenceParameter: {fileID: 11500000, guid: c39a0f918ce523344a209600d8f9ec40,
+          type: 3}
+        floatParameter: 0
+        intParameter: 0
+        messageOptions: 0
+      - time: 0.59901685
+        functionName: AttackRangeCollierTurnOff
         data: 
         objectReferenceParameter: {fileID: 11500000, guid: c39a0f918ce523344a209600d8f9ec40,
           type: 3}

--- a/Assets/Animations/Player/2Handed@Attack2.FBX.meta
+++ b/Assets/Animations/Player/2Handed@Attack2.FBX.meta
@@ -543,8 +543,16 @@ ModelImporter:
       bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
       curves: []
       events:
-      - time: 0.488024
-        functionName: AttackTrigger
+      - time: 0.465941
+        functionName: AttackRangeCollierTurnOn
+        data: 
+        objectReferenceParameter: {fileID: 11500000, guid: c39a0f918ce523344a209600d8f9ec40,
+          type: 3}
+        floatParameter: 0
+        intParameter: 0
+        messageOptions: 0
+      - time: 0.5976123
+        functionName: AttackRangeCollierTurnOff
         data: 
         objectReferenceParameter: {fileID: 11500000, guid: c39a0f918ce523344a209600d8f9ec40,
           type: 3}

--- a/Assets/Animations/Player/2Handed@Attack3.FBX.meta
+++ b/Assets/Animations/Player/2Handed@Attack3.FBX.meta
@@ -543,8 +543,16 @@ ModelImporter:
       bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
       curves: []
       events:
-      - time: 0.46107784
-        functionName: AttackTrigger
+      - time: 0.42169952
+        functionName: AttackRangeCollierTurnOn
+        data: 
+        objectReferenceParameter: {fileID: 11500000, guid: c39a0f918ce523344a209600d8f9ec40,
+          type: 3}
+        floatParameter: 0
+        intParameter: 0
+        messageOptions: 0
+      - time: 0.61762637
+        functionName: AttackRangeCollierTurnOff
         data: 
         objectReferenceParameter: {fileID: 11500000, guid: c39a0f918ce523344a209600d8f9ec40,
           type: 3}

--- a/Assets/Scenes/Player/Player.unity
+++ b/Assets/Scenes/Player/Player.unity
@@ -136,7 +136,7 @@ GameObject:
   - component: {fileID: 178740995}
   - component: {fileID: 178740994}
   m_Layer: 0
-  m_Name: Capsule
+  m_Name: Boss
   m_TagString: Boss
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -157,7 +157,7 @@ CapsuleCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
@@ -224,8 +224,8 @@ Transform:
   m_GameObject: {fileID: 178740993}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.556, y: 1.1662357, z: 0.111}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0.1714, y: 1.662, z: 0.111}
+  m_LocalScale: {x: 2, y: 2, z: 2}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -262,32 +262,78 @@ Transform:
   - {fileID: 1857102670}
   m_Father: {fileID: 454339740}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &454339734 stripped
+--- !u!1 &295598182
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1994513090600075941, guid: f140e689e2a78d54e828536c733f1d4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1079187732}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 295598183}
+  - component: {fileID: 295598184}
+  - component: {fileID: 295598185}
+  m_Layer: 3
+  m_Name: AttackRange
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &295598183
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 295598182}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0.08819887, z: 0, w: 0.9961029}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 986713132}
+  m_LocalEulerAnglesHint: {x: 0, y: -10.12, z: 0}
+--- !u!65 &295598184
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 295598182}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.40513256, y: 0.17380533, z: 0.9647337}
+  m_Center: {x: -0.2226882, y: -0.013137924, z: 1.9602475}
+--- !u!114 &295598185
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 295598182}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08056a7dc9a6964459586437d67372ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &454339740 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9055791104001212950, guid: f140e689e2a78d54e828536c733f1d4e,
     type: 3}
   m_PrefabInstance: {fileID: 1079187732}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &454339741
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 454339734}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6dbec4ac706ade645a0f8d1496a53ebd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  characterBody: {fileID: 2023829650}
-  cameraArm: {fileID: 185464122}
 --- !u!1 &833751080 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2481817077866643357, guid: f140e689e2a78d54e828536c733f1d4e,
@@ -432,12 +478,12 @@ PrefabInstance:
         type: 3}
       propertyPath: _rangeOfAttack
       value: 
-      objectReference: {fileID: 1640431014}
+      objectReference: {fileID: 0}
     - target: {fileID: 1955419867365339950, guid: f140e689e2a78d54e828536c733f1d4e,
         type: 3}
       propertyPath: _attackCollirer
       value: 
-      objectReference: {fileID: 1640431014}
+      objectReference: {fileID: 0}
     - target: {fileID: 1955419867365339950, guid: f140e689e2a78d54e828536c733f1d4e,
         type: 3}
       propertyPath: groundcheckDistance
@@ -457,6 +503,56 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Layer
       value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2209406782703079471, guid: f140e689e2a78d54e828536c733f1d4e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2209406782703079471, guid: f140e689e2a78d54e828536c733f1d4e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2209406782703079471, guid: f140e689e2a78d54e828536c733f1d4e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2209406782703079471, guid: f140e689e2a78d54e828536c733f1d4e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9961029
+      objectReference: {fileID: 0}
+    - target: {fileID: 2209406782703079471, guid: f140e689e2a78d54e828536c733f1d4e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2209406782703079471, guid: f140e689e2a78d54e828536c733f1d4e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.08819887
+      objectReference: {fileID: 0}
+    - target: {fileID: 2209406782703079471, guid: f140e689e2a78d54e828536c733f1d4e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2209406782703079471, guid: f140e689e2a78d54e828536c733f1d4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2209406782703079471, guid: f140e689e2a78d54e828536c733f1d4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -10.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 2209406782703079471, guid: f140e689e2a78d54e828536c733f1d4e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2474087039539688195, guid: f140e689e2a78d54e828536c733f1d4e,
         type: 3}
@@ -813,17 +909,13 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 9055791104001212950, guid: f140e689e2a78d54e828536c733f1d4e,
         type: 3}
-      insertIndex: -1
+      insertIndex: 0
       addedObject: {fileID: 185464122}
-    - targetCorrespondingSourceObject: {fileID: 2917617824821667798, guid: f140e689e2a78d54e828536c733f1d4e,
-        type: 3}
-      insertIndex: 2
-      addedObject: {fileID: 1640431014}
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 1994513090600075941, guid: f140e689e2a78d54e828536c733f1d4e,
+    - targetCorrespondingSourceObject: {fileID: 3467906221013865733, guid: f140e689e2a78d54e828536c733f1d4e,
         type: 3}
       insertIndex: -1
-      addedObject: {fileID: 454339741}
+      addedObject: {fileID: 295598183}
+    m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 2481817077866643357, guid: f140e689e2a78d54e828536c733f1d4e,
         type: 3}
       insertIndex: -1
@@ -953,6 +1045,111 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1079187732}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1212630011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1212630015}
+  - component: {fileID: 1212630014}
+  - component: {fileID: 1212630013}
+  - component: {fileID: 1212630012}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1212630012
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1212630011}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1212630013
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1212630011}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1212630014
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1212630011}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1212630015
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1212630011}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.25360423, y: -0.32147208, z: -0.2220506, w: 0.8848921}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: -36.27, y: -34.47, z: -16.57}
 --- !u!1 &1344635312
 GameObject:
   m_ObjectHideFlags: 0
@@ -1397,37 +1594,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1640431013
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1640431014}
-  m_Layer: 3
-  m_Name: RangeOfAttack
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1640431014
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1640431013}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.1594, z: 1.616}
-  m_LocalScale: {x: 1, y: 2.2812142, z: 2.3269}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2023829650}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1857102669
 GameObject:
   m_ObjectHideFlags: 0
@@ -1626,7 +1792,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _handWeapon: {fileID: 2101230549}
   _BackWeapon: {fileID: 1158129771}
-  _rangeOfAttack: {fileID: 1640431014}
+  _attackRange: {fileID: 295598182}
 --- !u!1 &2101230549 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3901650094347398186, guid: f140e689e2a78d54e828536c733f1d4e,
@@ -1644,3 +1810,4 @@ SceneRoots:
   - {fileID: 1344635316}
   - {fileID: 1403178946}
   - {fileID: 178740997}
+  - {fileID: 1212630015}

--- a/Assets/Scripts/Player/PlayerAnimationEvents.cs
+++ b/Assets/Scripts/Player/PlayerAnimationEvents.cs
@@ -8,7 +8,8 @@ public class PlayerAnimationEvents : MonoBehaviour
     [SerializeField] private GameObject _handWeapon;
     [SerializeField] private GameObject _BackWeapon;
 
-    [SerializeField] private Transform _rangeOfAttack;
+    [SerializeField] private GameObject _attackRange;
+
 
     private PlayerController _playerController;
 
@@ -17,6 +18,7 @@ public class PlayerAnimationEvents : MonoBehaviour
         _playerController = GetComponentInParent<PlayerController>();   
         _handWeapon.SetActive(false);
         _BackWeapon.SetActive(true);
+        _attackRange.SetActive(false);
     }
 
     public void DrawWeapon()
@@ -36,22 +38,13 @@ public class PlayerAnimationEvents : MonoBehaviour
         GetComponent<Animator>().speed = 0.03f;
     }
 
-    private void AttackTrigger()
+    public void AttackRangeCollierTurnOn()
     {
-        Collider[] colliders = Physics.OverlapBox(_rangeOfAttack.position, new Vector3(1, 2, 1.5f));
-            //.OverlapSphere(_rangeOfAttack.position, 1f);
-            //OverlapCircleAll(player.attackCheck.position, player.attackCheckRadius);
-        
-        foreach (var hit in colliders)
-        {
-            if (hit.CompareTag("Boss"))
-            {
-                BattleManager.TakeDamage("Player", BattleManager._playerAttackDamege);
-                Debug.Log($"Attack Damege : {BattleManager._playerAttackDamege}");
-            }
-        }
-
+        _attackRange.SetActive(true);
     }
 
-
+    public void AttackRangeCollierTurnOff()
+    {
+        _attackRange.SetActive(false);
+    }
 }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -30,7 +30,6 @@ public class PlayerController : MonoBehaviour
     [Header("Object")]
     [SerializeField] private Transform _characterBody;
     [SerializeField] private Transform _cameraArm;
-    [SerializeField] private Transform _rangeOfAttack;
 
     [Header("GroundCheck")]
     [SerializeField] private float groundcheckDistance;
@@ -66,11 +65,6 @@ public class PlayerController : MonoBehaviour
         LookAround();
 
         
-    }
-
-    private void OnDrawGizmos()
-    {
-        Gizmos.DrawWireCube(_rangeOfAttack.position, new Vector3(1, 2 , 1.5f));
     }
 
     private void GroundCheck()

--- a/Assets/Scripts/Player/Weapon.cs
+++ b/Assets/Scripts/Player/Weapon.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.Burst.CompilerServices;
+using UnityEngine;
+
+public class Weapon : MonoBehaviour
+{
+
+    /*    private void OnCollisionEnter(Collision collision)
+        {
+            Debug.Log("Attack");
+            if (collision.gameObject.CompareTag("Boss"))
+            {
+                //추후 타격 지점에 타격 이펙트 생성 때 사용 예정
+                //Vector3 pointOfContact = collision.contacts[0].point;
+
+                BattleManager.TakeDamage("Player", BattleManager._playerAttackDamege);
+                Debug.Log(BattleManager._playerAttackDamege);
+
+            }
+
+        }*/
+
+    private void OnTriggerEnter(Collider other)
+    {
+        Debug.Log("Attack");
+        if (other.CompareTag("Boss"))
+        {
+            //타격 지점 계산
+            Vector3 hitPos = other.ClosestPoint(transform.position);
+
+
+            BattleManager.TakeDamage("Player", BattleManager._playerAttackDamege);
+            Debug.Log(BattleManager._playerAttackDamege);
+
+        }
+    }
+}

--- a/Assets/Scripts/Player/Weapon.cs.meta
+++ b/Assets/Scripts/Player/Weapon.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08056a7dc9a6964459586437d67372ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -7,6 +7,8 @@ TagManager:
   - Ground
   - Boss
   - Monster
+  - Collide
+  - Weapon
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
# 설명

## 기존 방식
1. Animation Event로 AttackTrigger함수 실행
2. Physics.OverlapBox로 공격 범위 내collier들 가져와서 Boss Tag인 객체에 체력 감소

### 문제점
1. Physics.OverlapBox 범위내에 보스의 여러 부위가 들어가 있다면 모든 부위에 공격 판정이 들어가 데미지가 중첩되서 들어갈수 있었다.

### 수정 이유
1. 보스 약점 시스템 구현시 정밀한 타격 을 요구 하기 때문에 수정했다.

## 수정 사항
1. Physics.OverlapBox 삭제 1. Player의 무기에 AttackRange오브젝트 생성

2. 기존 Animation Event의 AttackTrigger 삭제 1.  Animation Event 변경 1. Attack 1(좌클릭 어택 애니메이션) 1. AnimationPause : 애니메이터의 속도를 늦춰 차징되는 연출 표현 2. AttackRangeCollierTurnOn : AttackRange의 collider를 활성화 한다. 3. AttackRangeCollierTurnOff :: AttackRange의 collider를 비활성화 한다.

        1. Attack 2 (우클릭 1타 애니메이션)
            1. AttackRangeCollierTurnOn : AttackRange의 collider를 활성화 한다.
            2. AttackRangeCollierTurnOff :: AttackRange의 collider를 비활성화 한다.

        1. Attack 3 (우클릭 2타 애니메이션)
            1. AttackRangeCollierTurnOn : AttackRange의 collider를 활성화 한다.
            2. AttackRangeCollierTurnOff :: AttackRange의 collider를 비활성화 한다.

3. AttackRange 오브젝트에 Weapon.cs 파일 추가 1. OnTriggerEnter로 Boss와 충돌시 보스 데미지 감소 기능 구현