### PR TITLE
MON-99-BossWeaknessSystem

### DIFF
--- a/Assets/BossWeakness.cs
+++ b/Assets/BossWeakness.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+
+public class BossWeakness : MonoBehaviour
+{
+    [SerializeField]
+    private int _countHitByWeapon;
+
+    private void Awake()
+    {
+        _countHitByWeapon = 0;
+    }
+
+    private void Update()
+    {
+        if (_countHitByWeapon == 5)
+        {
+            CombatManager._isBossSturned = true;
+            _countHitByWeapon = 0;
+        }
+    }
+
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Weapon"))
+        {
+            _countHitByWeapon++;
+        }
+    }
+
+}

--- a/Assets/BossWeakness.cs.meta
+++ b/Assets/BossWeakness.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 696f492b2b2865b4ba718dede2fb8958
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dinosaur_Pack1/Trex/Animation/Trex@Hit.fbx.meta
+++ b/Assets/Dinosaur_Pack1/Trex/Animation/Trex@Hit.fbx.meta
@@ -31,7 +31,36 @@ ModelImporter:
     animationWrapMode: 0
     extraExposedTransformPaths: []
     extraUserProperties: []
-    clipAnimations: []
+    clipAnimations:
+    - serializedVersion: 16
+      name: Hit
+      takeName: Take 001
+      internalID: 1827226128182048838
+      firstFrame: 0
+      lastFrame: 26
+      wrapMode: 0
+      orientationOffsetY: 0
+      level: 0
+      cycleOffset: 0
+      loop: 0
+      hasAdditiveReferencePose: 0
+      loopTime: 1
+      loopBlend: 0
+      loopBlendOrientation: 0
+      loopBlendPositionY: 0
+      loopBlendPositionXZ: 0
+      keepOriginalOrientation: 0
+      keepOriginalPositionY: 1
+      keepOriginalPositionXZ: 0
+      heightFromFeet: 0
+      mirror: 0
+      bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
+      curves: []
+      events: []
+      transformMask: []
+      maskType: 3
+      maskSource: {instanceID: 0}
+      additiveReferencePoseFrame: 0
     isReadable: 0
   meshes:
     lODScreenPercentages: []

--- a/Assets/Prefabs/Trex.prefab
+++ b/Assets/Prefabs/Trex.prefab
@@ -95,111 +95,6 @@ Transform:
   - {fileID: 5749011230677487936}
   m_Father: {fileID: 2441098818059538643}
   m_LocalEulerAnglesHint: {x: -0.53548586, y: 1.9077244, z: -172.46193}
---- !u!1 &802569150194177409
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7523497139849238587}
-  - component: {fileID: 626175311479434602}
-  - component: {fileID: 7041842857217116808}
-  - component: {fileID: 8667602609357161080}
-  m_Layer: 6
-  m_Name: Sphere
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &7523497139849238587
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 802569150194177409}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4578358827111341722}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &626175311479434602
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 802569150194177409}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &7041842857217116808
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 802569150194177409}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &8667602609357161080
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 802569150194177409}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &820196267587324381
 GameObject:
   m_ObjectHideFlags: 0
@@ -455,61 +350,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7167517976628988405}
   m_LocalEulerAnglesHint: {x: 3.0090545e-15, y: -0.0000016154738, z: 0.00000012050158}
---- !u!1 &1819415507536899074
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1651453523603037109}
-  - component: {fileID: 4238763695884666043}
-  m_Layer: 6
-  m_Name: BossBodyCollider
-  m_TagString: Untagged
-  m_Icon: {fileID: 419385456094870383, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1651453523603037109
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1819415507536899074}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2441098818059538643}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &4238763695884666043
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1819415507536899074}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.9
-  m_Height: 3.56
-  m_Direction: 0
-  m_Center: {x: -0.5, y: 0.2, z: 0}
 --- !u!1 &2010347308597839756
 GameObject:
   m_ObjectHideFlags: 0
@@ -603,8 +443,7 @@ Transform:
   m_LocalPosition: {x: -0.30585736, y: 1.3055472, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7523497139849238587}
+  m_Children: []
   m_Father: {fileID: 1381617344614925454}
   m_LocalEulerAnglesHint: {x: -89.45, y: 90, z: 0}
 --- !u!136 &3805335795443356703
@@ -642,8 +481,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d4c2d6f98e193d64690dc84673ebaf84, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  nomalAttackCollider: {fileID: 2717294989959313186}
-  nomalAttack: 10
+  _nomalAttack: 0
+  _hitprefab: {fileID: 0}
+  _hitEffect: {fileID: 0}
 --- !u!1 &2950329293331711003
 GameObject:
   m_ObjectHideFlags: 0
@@ -708,7 +548,6 @@ Transform:
   - {fileID: 7095447886137228065}
   - {fileID: 3486036272547172009}
   - {fileID: 1427035691365408184}
-  - {fileID: 7411503333513864768}
   m_Father: {fileID: 7588234217510130016}
   m_LocalEulerAnglesHint: {x: 0.3138506, y: 1.5702336, z: 5.5689073}
 --- !u!1 &3063201237040743895
@@ -811,7 +650,7 @@ GameObject:
   - component: {fileID: 3814694049581865422}
   - component: {fileID: 483806206429769679}
   m_Layer: 6
-  m_Name: Breath
+  m_Name: BreathAttack
   m_TagString: Untagged
   m_Icon: {fileID: 5132851093641282708, guid: 0000000000000000d000000000000000, type: 0}
   m_NavMeshLayer: 0
@@ -825,13 +664,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3563143149603190167}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.038095612, y: -0.00016061978, z: -0.058689635, w: 0.9975491}
-  m_LocalPosition: {x: 0.55, y: 4.49, z: 0.14}
+  m_LocalRotation: {x: -0.000000037820897, y: -0.000000028794023, z: -0.025514444,
+    w: 0.99967444}
+  m_LocalPosition: {x: -0.000013113022, y: 4.6800184, z: -0.00000013171348}
   m_LocalScale: {x: 1, y: 2.97, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8574478185057619615}
-  m_LocalEulerAnglesHint: {x: 4.358, y: -0.275, z: -6.745}
+  m_Father: {fileID: 1381617344614925454}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -2.924}
 --- !u!33 &2228943687183816830
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -917,7 +757,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 27bd8dfb2c9a51044b5f910d0f205299, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  breathAttack: 5
+  _breathAttack: 0
 --- !u!1 &3818249928515855094
 GameObject:
   m_ObjectHideFlags: 0
@@ -1109,61 +949,6 @@ Transform:
   - {fileID: 4185590961685861976}
   m_Father: {fileID: 1996650413442837277}
   m_LocalEulerAnglesHint: {x: 0.000025841364, y: 0.000009560456, z: 89.66994}
---- !u!1 &4755877286862218582
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7411503333513864768}
-  - component: {fileID: 6151442147738148898}
-  m_Layer: 6
-  m_Name: BossNeckCollider
-  m_TagString: Untagged
-  m_Icon: {fileID: 419385456094870383, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7411503333513864768
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4755877286862218582}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1857356080511780103}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &6151442147738148898
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4755877286862218582}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.56
-  m_Height: 2.23
-  m_Direction: 0
-  m_Center: {x: -0.49, y: 0, z: 0}
 --- !u!1 &5507715271306925638
 GameObject:
   m_ObjectHideFlags: 0
@@ -1291,62 +1076,6 @@ Transform:
   - {fileID: 1381617344614925454}
   m_Father: {fileID: 1857356080511780103}
   m_LocalEulerAnglesHint: {x: -1.7799895, y: 3.6709733, z: 6.3387394}
---- !u!1 &6113781789721250876
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8574478185057619615}
-  - component: {fileID: 4781487173362516635}
-  m_Layer: 6
-  m_Name: BossHeadCollider
-  m_TagString: Untagged
-  m_Icon: {fileID: 419385456094870383, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8574478185057619615
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6113781789721250876}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7764201257419764958}
-  m_Father: {fileID: 1381617344614925454}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &4781487173362516635
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6113781789721250876}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.59
-  m_Height: 2.24
-  m_Direction: 1
-  m_Center: {x: -0.29, y: 0.59, z: 0}
 --- !u!1 &6179559274813268322
 GameObject:
   m_ObjectHideFlags: 0
@@ -1633,7 +1362,6 @@ Transform:
   - {fileID: 9211993918056592998}
   - {fileID: 6949227224561889782}
   - {fileID: 9017704260323018190}
-  - {fileID: 1651453523603037109}
   m_Father: {fileID: 2379715448692019679}
   m_LocalEulerAnglesHint: {x: -83.44933, y: 12.768923, z: 83.79318}
 --- !u!1 &7191000721542470380
@@ -1814,13 +1542,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 668cdace8166210438a529efa22b6874, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moveSpeed: 10
-  rotationSpeed: 200
-  player: {fileID: 0}
-  breath: {fileID: 3563143149603190167}
-  canBreathAttack: 0
+  _moveSpeed: 0
+  _rotationSpeed: 0
+  _player: {fileID: 0}
+  _nomalAtt: {fileID: 0}
+  _breathAtt: {fileID: 0}
   isBossGetHit: 0
   isBossDead: 0
+  _detectedPlayer: 0
+  _trackingPlayer: 0
+  _perceptionTime: 0
+  _canNomalWalking: 0
+  _randomPosToWalk: {x: 0, y: 0, z: 0}
 --- !u!54 &4642371981902151020
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -2006,6 +1739,7 @@ GameObject:
   m_Component:
   - component: {fileID: 97150703056962411}
   - component: {fileID: 5018197220114000201}
+  - component: {fileID: 2227856351393536898}
   m_Layer: 6
   m_Name: T_Rex_low_low_
   m_TagString: Untagged
@@ -2127,6 +1861,14 @@ SkinnedMeshRenderer:
     m_Center: {x: 1.329047, y: 0.73937166, z: -0.0000017285347}
     m_Extent: {x: 6.314828, y: 2.610931, z: 1.2765617}
   m_DirtyAABB: 0
+--- !u!33 &2227856351393536898
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8520873568579796104}
+  m_Mesh: {fileID: 586917104563912296, guid: 22f3efffe4ef8da4ea9adae986b4e866, type: 3}
 --- !u!1 &8831596827720760981
 GameObject:
   m_ObjectHideFlags: 0
@@ -2160,7 +1902,7 @@ Transform:
   - {fileID: 1271441805145828251}
   - {fileID: 8684713418679688960}
   - {fileID: 4578358827111341722}
-  - {fileID: 8574478185057619615}
+  - {fileID: 7764201257419764958}
   m_Father: {fileID: 3486036272547172009}
   m_LocalEulerAnglesHint: {x: -5.379525, y: -2.7788455, z: 65.3174}
 --- !u!1 &8885669014565789462

--- a/Assets/Scenes/Boss/BossScene.unity
+++ b/Assets/Scenes/Boss/BossScene.unity
@@ -549,6 +549,75 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 907181306}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &874176320
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 874176321}
+  - component: {fileID: 874176322}
+  - component: {fileID: 874176323}
+  m_Layer: 6
+  m_Name: Weakness
+  m_TagString: Weakness
+  m_Icon: {fileID: 3936346786652291628, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &874176321
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 874176320}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.28, y: 0.61, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2093431389}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &874176322
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 874176320}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.59
+  m_Height: 2.19
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &874176323
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 874176320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 696f492b2b2865b4ba718dede2fb8958, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _countHitByWeapon: 0
 --- !u!1001 &907181306
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -557,10 +626,85 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 308167556702219691, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -1.8718753
+      objectReference: {fileID: 0}
+    - target: {fileID: 308167556702219691, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -4.7704477
+      objectReference: {fileID: 0}
+    - target: {fileID: 308167556702219691, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -13.895566
+      objectReference: {fileID: 0}
+    - target: {fileID: 761510502421775722, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.00000015448757
+      objectReference: {fileID: 0}
+    - target: {fileID: 761510502421775722, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.0000049940654
+      objectReference: {fileID: 0}
+    - target: {fileID: 761510502421775722, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 5.938422
+      objectReference: {fileID: 0}
+    - target: {fileID: 772394993195112202, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 1.5028383
+      objectReference: {fileID: 0}
+    - target: {fileID: 772394993195112202, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 12.743304
+      objectReference: {fileID: 0}
+    - target: {fileID: 772394993195112202, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 10.072459
+      objectReference: {fileID: 0}
     - target: {fileID: 802569150194177409, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 905752054683605284, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 30.315874
+      objectReference: {fileID: 0}
+    - target: {fileID: 905752054683605284, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -1.5407697
+      objectReference: {fileID: 0}
+    - target: {fileID: 905752054683605284, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -94.55367
+      objectReference: {fileID: 0}
+    - target: {fileID: 974116091484376654, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.00000013028571
+      objectReference: {fileID: 0}
+    - target: {fileID: 974116091484376654, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.00000006682885
+      objectReference: {fileID: 0}
+    - target: {fileID: 974116091484376654, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 5.9384356
       objectReference: {fileID: 0}
     - target: {fileID: 983852566087758812, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
@@ -594,6 +738,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 983852566087758812, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
+      propertyPath: _isBossSturned
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 983852566087758812, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
       propertyPath: _rotationSpeed
       value: 200
       objectReference: {fileID: 0}
@@ -602,12 +751,252 @@ PrefabInstance:
       propertyPath: _doNomalWalking
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1271441805145828251, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -59.596046
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271441805145828251, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 8.898206
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271441805145828251, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -166.2887
+      objectReference: {fileID: 0}
+    - target: {fileID: 1381046273182357025, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.000005030909
+      objectReference: {fileID: 0}
+    - target: {fileID: 1381046273182357025, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.0000009883782
+      objectReference: {fileID: 0}
+    - target: {fileID: 1381046273182357025, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 76.499275
+      objectReference: {fileID: 0}
+    - target: {fileID: 1381617344614925454, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 8.385146
+      objectReference: {fileID: 0}
+    - target: {fileID: 1381617344614925454, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 5.3761463
+      objectReference: {fileID: 0}
+    - target: {fileID: 1381617344614925454, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 34.136234
+      objectReference: {fileID: 0}
+    - target: {fileID: 1384190840228261876, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.76385295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1384190840228261876, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -14.131927
+      objectReference: {fileID: 0}
+    - target: {fileID: 1384190840228261876, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 19.274971
+      objectReference: {fileID: 0}
+    - target: {fileID: 1427035691365408184, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -16.370785
+      objectReference: {fileID: 0}
+    - target: {fileID: 1427035691365408184, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 88.31439
+      objectReference: {fileID: 0}
+    - target: {fileID: 1427035691365408184, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -101.489685
+      objectReference: {fileID: 0}
+    - target: {fileID: 1666318213039376700, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.0000012869655
+      objectReference: {fileID: 0}
+    - target: {fileID: 1666318213039376700, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.000000997655
+      objectReference: {fileID: 0}
+    - target: {fileID: 1666318213039376700, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -77.88612
+      objectReference: {fileID: 0}
+    - target: {fileID: 1676528629645199712, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.000000027211854
+      objectReference: {fileID: 0}
+    - target: {fileID: 1676528629645199712, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.0000052558407
+      objectReference: {fileID: 0}
+    - target: {fileID: 1676528629645199712, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 5.9384317
+      objectReference: {fileID: 0}
+    - target: {fileID: 1717352528331757747, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1819415507536899074, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1857356080511780103, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.14503327
+      objectReference: {fileID: 0}
+    - target: {fileID: 1857356080511780103, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 1.1994883
+      objectReference: {fileID: 0}
+    - target: {fileID: 1857356080511780103, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -18.091042
+      objectReference: {fileID: 0}
+    - target: {fileID: 1996650413442837277, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 63.833958
+      objectReference: {fileID: 0}
+    - target: {fileID: 1996650413442837277, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -3.164247
+      objectReference: {fileID: 0}
+    - target: {fileID: 1996650413442837277, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0.8046577
+      objectReference: {fileID: 0}
+    - target: {fileID: 2214547120508900761, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -1.2219572
+      objectReference: {fileID: 0}
+    - target: {fileID: 2214547120508900761, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 3.397095
+      objectReference: {fileID: 0}
+    - target: {fileID: 2214547120508900761, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -71.5814
+      objectReference: {fileID: 0}
+    - target: {fileID: 2379715448692019679, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 83.33602
+      objectReference: {fileID: 0}
+    - target: {fileID: 2379715448692019679, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 179.99945
+      objectReference: {fileID: 0}
+    - target: {fileID: 2379715448692019679, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -90.000534
+      objectReference: {fileID: 0}
+    - target: {fileID: 2385044323508162477, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -4.1879573
+      objectReference: {fileID: 0}
+    - target: {fileID: 2385044323508162477, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.3136471
+      objectReference: {fileID: 0}
+    - target: {fileID: 2385044323508162477, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -25.809801
+      objectReference: {fileID: 0}
+    - target: {fileID: 2441098818059538643, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -85.98688
+      objectReference: {fileID: 0}
+    - target: {fileID: 2441098818059538643, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 6.210625
+      objectReference: {fileID: 0}
+    - target: {fileID: 2441098818059538643, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 92.98077
+      objectReference: {fileID: 0}
+    - target: {fileID: 2463279449231589581, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -69.48376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2463279449231589581, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 9.103563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2463279449231589581, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 7.3680215
+      objectReference: {fileID: 0}
     - target: {fileID: 2717294989959313186, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
       propertyPath: m_Icon
       value: 
       objectReference: {fileID: 5132851093641282708, guid: 0000000000000000d000000000000000,
         type: 0}
+    - target: {fileID: 2997772196906402515, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -14.535621
+      objectReference: {fileID: 0}
+    - target: {fileID: 2997772196906402515, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.11747152
+      objectReference: {fileID: 0}
+    - target: {fileID: 2997772196906402515, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -94.07522
+      objectReference: {fileID: 0}
+    - target: {fileID: 3063201237040743895, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3103622398804924886, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
       propertyPath: _nomalAttack
@@ -618,10 +1007,320 @@ PrefabInstance:
       propertyPath: _capsuleCollider
       value: 
       objectReference: {fileID: 502822952}
+    - target: {fileID: 3242243453576412258, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 171.10165
+      objectReference: {fileID: 0}
+    - target: {fileID: 3242243453576412258, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -37.711086
+      objectReference: {fileID: 0}
+    - target: {fileID: 3486036272547172009, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -1.3985982
+      objectReference: {fileID: 0}
+    - target: {fileID: 3486036272547172009, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 3.3397884
+      objectReference: {fileID: 0}
+    - target: {fileID: 3486036272547172009, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 8.330672
+      objectReference: {fileID: 0}
+    - target: {fileID: 3582296373244782303, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.000000024377357
+      objectReference: {fileID: 0}
+    - target: {fileID: 3582296373244782303, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.0000021491494
+      objectReference: {fileID: 0}
+    - target: {fileID: 3582296373244782303, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 5.9384317
+      objectReference: {fileID: 0}
+    - target: {fileID: 3620252805442057280, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 1.2219577
+      objectReference: {fileID: 0}
+    - target: {fileID: 3620252805442057280, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -3.3970938
+      objectReference: {fileID: 0}
+    - target: {fileID: 3620252805442057280, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -70.23873
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740036011291483141, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 1.9643887
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740036011291483141, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 10.835566
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740036011291483141, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 41.433556
+      objectReference: {fileID: 0}
+    - target: {fileID: 3805335795443356703, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_Radius
+      value: 0.68
+      objectReference: {fileID: 0}
     - target: {fileID: 3805335795443356703, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
       propertyPath: m_Center.z
-      value: -0.34
+      value: -0.62
+      objectReference: {fileID: 0}
+    - target: {fileID: 3893449479406248894, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.0000026003827
+      objectReference: {fileID: 0}
+    - target: {fileID: 3893449479406248894, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.0000047893054
+      objectReference: {fileID: 0}
+    - target: {fileID: 3893449479406248894, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 5.9384336
+      objectReference: {fileID: 0}
+    - target: {fileID: 4185590961685861976, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 27.965174
+      objectReference: {fileID: 0}
+    - target: {fileID: 4185590961685861976, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -3.8147197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4185590961685861976, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -70.32351
+      objectReference: {fileID: 0}
+    - target: {fileID: 4342220372980532113, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.00000005919867
+      objectReference: {fileID: 0}
+    - target: {fileID: 4342220372980532113, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.00000013843717
+      objectReference: {fileID: 0}
+    - target: {fileID: 4342220372980532113, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 66.3831
+      objectReference: {fileID: 0}
+    - target: {fileID: 4686636626391829018, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.000000020975776
+      objectReference: {fileID: 0}
+    - target: {fileID: 4686636626391829018, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.0000036589004
+      objectReference: {fileID: 0}
+    - target: {fileID: 4686636626391829018, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 5.9384294
+      objectReference: {fileID: 0}
+    - target: {fileID: 4729086539996394579, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 4.1879573
+      objectReference: {fileID: 0}
+    - target: {fileID: 4729086539996394579, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.31364518
+      objectReference: {fileID: 0}
+    - target: {fileID: 4729086539996394579, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -14.650484
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732515585997766633, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -7.781083
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732515585997766633, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -163.718
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732515585997766633, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -146.48132
+      objectReference: {fileID: 0}
+    - target: {fileID: 4755877286862218582, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4781487173362516635, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5018197220114000201, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5090018093265087472, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -1.349005
+      objectReference: {fileID: 0}
+    - target: {fileID: 5090018093265087472, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 2.338225
+      objectReference: {fileID: 0}
+    - target: {fileID: 5090018093265087472, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.4086943
+      objectReference: {fileID: 0}
+    - target: {fileID: 5339118695673960458, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 14.536139
+      objectReference: {fileID: 0}
+    - target: {fileID: 5339118695673960458, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.1192177
+      objectReference: {fileID: 0}
+    - target: {fileID: 5339118695673960458, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -94.09492
+      objectReference: {fileID: 0}
+    - target: {fileID: 5749011230677487936, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.8208918
+      objectReference: {fileID: 0}
+    - target: {fileID: 5749011230677487936, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.9822544
+      objectReference: {fileID: 0}
+    - target: {fileID: 5749011230677487936, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 9.101238
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113781789721250876, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6151442147738148898, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_Height
+      value: 1.6928517
+      objectReference: {fileID: 0}
+    - target: {fileID: 6151442147738148898, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -0.47823733
+      objectReference: {fileID: 0}
+    - target: {fileID: 6151442147738148898, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 0.0000000749387
+      objectReference: {fileID: 0}
+    - target: {fileID: 6151442147738148898, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.000000027433597
+      objectReference: {fileID: 0}
+    - target: {fileID: 6861960690275217404, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -27.961874
+      objectReference: {fileID: 0}
+    - target: {fileID: 6861960690275217404, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 3.816597
+      objectReference: {fileID: 0}
+    - target: {fileID: 6861960690275217404, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -65.72516
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949227224561889782, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.15664029
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949227224561889782, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 2.302864
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949227224561889782, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 7.543852
+      objectReference: {fileID: 0}
+    - target: {fileID: 7095447886137228065, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 16.407572
+      objectReference: {fileID: 0}
+    - target: {fileID: 7095447886137228065, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90.73143
+      objectReference: {fileID: 0}
+    - target: {fileID: 7095447886137228065, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -106.168846
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167517976628988405, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -30.314655
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167517976628988405, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 1.4548239
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167517976628988405, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -94.5091
       objectReference: {fileID: 0}
     - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
@@ -673,20 +1372,35 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7588234217510130016, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -1.9213567
+      objectReference: {fileID: 0}
+    - target: {fileID: 7588234217510130016, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 2.2030325
+      objectReference: {fileID: 0}
+    - target: {fileID: 7588234217510130016, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -32.98159
+      objectReference: {fileID: 0}
     - target: {fileID: 7764201257419764958, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.54996514
+      value: 0.55
       objectReference: {fileID: 0}
     - target: {fileID: 7764201257419764958, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.4900537
+      value: 4.49
       objectReference: {fileID: 0}
     - target: {fileID: 7764201257419764958, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.14000036
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 7764201257419764958, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
         type: 3}
@@ -728,12 +1442,192 @@ PrefabInstance:
       propertyPath: m_Name
       value: Trex
       objectReference: {fileID: 0}
+    - target: {fileID: 7800857922649941904, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8172248218934493910, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.28548902
+      objectReference: {fileID: 0}
+    - target: {fileID: 8172248218934493910, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.7183156
+      objectReference: {fileID: 0}
+    - target: {fileID: 8172248218934493910, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -92.411194
+      objectReference: {fileID: 0}
+    - target: {fileID: 8293679563381414222, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.28456423
+      objectReference: {fileID: 0}
+    - target: {fileID: 8293679563381414222, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.71836144
+      objectReference: {fileID: 0}
+    - target: {fileID: 8293679563381414222, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -92.46387
+      objectReference: {fileID: 0}
+    - target: {fileID: 8331460322443163873, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.000004189182
+      objectReference: {fileID: 0}
+    - target: {fileID: 8331460322443163873, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.0000013186146
+      objectReference: {fileID: 0}
+    - target: {fileID: 8331460322443163873, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -87.22946
+      objectReference: {fileID: 0}
+    - target: {fileID: 8520873568579796104, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8520873568579796104, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_TagString
+      value: Boss
+      objectReference: {fileID: 0}
+    - target: {fileID: 8684713418679688960, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.00016598734
+      objectReference: {fileID: 0}
+    - target: {fileID: 8684713418679688960, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -179.99997
+      objectReference: {fileID: 0}
+    - target: {fileID: 8684713418679688960, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -86.75611
+      objectReference: {fileID: 0}
+    - target: {fileID: 8831222668396581199, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.000003585938
+      objectReference: {fileID: 0}
+    - target: {fileID: 8831222668396581199, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.000011985214
+      objectReference: {fileID: 0}
+    - target: {fileID: 8831222668396581199, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 97.48739
+      objectReference: {fileID: 0}
+    - target: {fileID: 9017704260323018190, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.029713571
+      objectReference: {fileID: 0}
+    - target: {fileID: 9017704260323018190, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 8.428214
+      objectReference: {fileID: 0}
+    - target: {fileID: 9017704260323018190, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -168.06091
+      objectReference: {fileID: 0}
+    - target: {fileID: 9206415539037951206, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.000001762166
+      objectReference: {fileID: 0}
+    - target: {fileID: 9206415539037951206, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.000001549801
+      objectReference: {fileID: 0}
+    - target: {fileID: 9206415539037951206, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 98.22723
+      objectReference: {fileID: 0}
+    - target: {fileID: 9211993918056592998, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 13.677353
+      objectReference: {fileID: 0}
+    - target: {fileID: 9211993918056592998, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 175.38304
+      objectReference: {fileID: 0}
+    - target: {fileID: 9211993918056592998, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -115.078224
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 802569150194177409, guid: 2c50569d6f59a0a40b46eb47c5ea7343, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 1381617344614925454, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 874176321}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3063201237040743895, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 907181308}
+    - targetCorrespondingSourceObject: {fileID: 8520873568579796104, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2037884431}
+    - targetCorrespondingSourceObject: {fileID: 8520873568579796104, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2037884430}
   m_SourcePrefab: {fileID: 100100000, guid: 2c50569d6f59a0a40b46eb47c5ea7343, type: 3}
+--- !u!1 &907181307 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3063201237040743895, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+    type: 3}
+  m_PrefabInstance: {fileID: 907181306}
+  m_PrefabAsset: {fileID: 0}
+--- !u!136 &907181308
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 907181307}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 1.2563559
+  m_Height: 14.705836
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.76228, z: 1.9696674}
 --- !u!1 &1175074415
 GameObject:
   m_ObjectHideFlags: 0
@@ -1642,6 +2536,48 @@ Transform:
   m_Children: []
   m_Father: {fileID: 374865698}
   m_LocalEulerAnglesHint: {x: -36.798, y: -376.565, z: -20.824001}
+--- !u!1 &2037884427 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8520873568579796104, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+    type: 3}
+  m_PrefabInstance: {fileID: 907181306}
+  m_PrefabAsset: {fileID: 0}
+--- !u!64 &2037884430
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2037884427}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: -1
+  m_Mesh: {fileID: 586917104563912296, guid: 22f3efffe4ef8da4ea9adae986b4e866, type: 3}
+--- !u!33 &2037884431
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2037884427}
+  m_Mesh: {fileID: 586917104563912296, guid: 22f3efffe4ef8da4ea9adae986b4e866, type: 3}
+--- !u!4 &2093431389 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1381617344614925454, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
+    type: 3}
+  m_PrefabInstance: {fileID: 907181306}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Boss/CombatManager.cs
+++ b/Assets/Scripts/Boss/CombatManager.cs
@@ -13,18 +13,18 @@ public class CombatManager : MonoBehaviour
     public static float _currentBossHP { get; set; }
     public static float _currentPlayerHP;
 
-    public static float _attackRange = 3.5f;
     public static bool _isPlayerDead = false;
     public static bool _isBossDead { get; set; } = false;
+    public static bool _isBossSturned;
+    public static bool _isbossGetHit;
+    public static bool _isBossRecognizedPlayer;
 
     public static float distancePtoB;
     public static bool _bossAttackRange;
     public static bool _bossAttackBackRange;
     public static bool _bossVisualRange;
     public static bool _bossPerceptionRange;
-    public static bool _isbossRecognizedPlayer;
 
-    public static bool _bossGetHit;
 
     void Awake()
     {
@@ -69,14 +69,7 @@ public class CombatManager : MonoBehaviour
         if (_isForward > 0 && distancePtoB <= 9f)
         {
             _bossAttackRange = true;
-            _bossAttackBackRange = false;
-            _isbossRecognizedPlayer = true;
-        }
-        else if (_isForward < 0 && distancePtoB <= 9f)
-        {
-            _bossAttackRange = false;
-            _bossAttackBackRange = true;
-            _isbossRecognizedPlayer = true;
+            _isBossRecognizedPlayer = true;
         }
         else
         {
@@ -85,8 +78,16 @@ public class CombatManager : MonoBehaviour
         }
 
         // 시야 범위
-        if (_isForward > 0 && distancePtoB <= 18f) _bossVisualRange = true;
-        else _bossVisualRange = false;
+        if (_isForward > 0 && distancePtoB <= 18f)
+        {
+            _bossVisualRange = true;
+            _isBossRecognizedPlayer = true;
+        }
+        else 
+        {
+            _bossVisualRange = false;
+            _isBossRecognizedPlayer = false;
+        }
 
         //인식 범위
         if (distancePtoB <= 18f) _bossPerceptionRange = true;
@@ -103,12 +104,12 @@ public class CombatManager : MonoBehaviour
     {
         if (type == "Player")
             _currentBossHP -= damage;
-            _isbossRecognizedPlayer = true;
+            _isBossRecognizedPlayer = true;
         if (type == "Boss")
         {
             _currentPlayerHP -= damage;
-            _bossGetHit = true;
-            _bossGetHit = false;
+            _isbossGetHit = true;
+            _isbossGetHit = false;
         }
     }
 

--- a/Assets/Scripts/Boss/NomalAttackTrigger.cs
+++ b/Assets/Scripts/Boss/NomalAttackTrigger.cs
@@ -48,7 +48,7 @@ public class NomalAttackTrigger : MonoBehaviour
     /// boss의 nomalAttack에 충돌된 위치에 HitEffect를 나타내는 코루틴을 실행합니다.
     /// 해당 코루틴은 CoHitEffect입니다.
     /// </summary>
-    /// <param name="hitPos">플레이어가 보스에게 맞은 곳</param>
+    /// <param name="hitPos">충돌된 개체가 맞은 곳</param>
     /// <param name="player">충돌된 개체 = Player</param>
     public void AppearHitEffect(Vector3 hitPos, GameObject player)
     {
@@ -63,6 +63,7 @@ public class NomalAttackTrigger : MonoBehaviour
             _hitEffect = Instantiate(_hitprefab);
             _hitEffect.transform.parent = player.transform;
         }
+
         _hitEffect.transform.position = hitPos;
         _hitEffect.SetActive(true);
         yield return new WaitForSeconds(1f);

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -7,6 +7,8 @@ TagManager:
   - Ground
   - Boss
   - Monster
+  - Weakness
+  - Weapon
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
##설명
1. 보스가 일정 횟수 이상 약점을 맞으면 기절에 걸리는 시스템입니다. 이에 따라 보스의 머리 부분에 콜리더를 포함한 Weakness오브젝트를 추가하였고, BossWeakness.cs로 해당 시스템을 구현하였습니다.
2. 플레이어가 소지하고 있는 무기에 weapon 태그를 달아서 해당 태그와 TriggerEnter 되면 _countHitByWeapon변수를 1씩 올려 해당 값이 5가 되면 초기화 하며 CombatManager로 스턴 상태임을 전달합니다.
3. CombatManager클래스에서 보스가 스턴 상태인지 확인하는 bool형 _isBossSturned 변수를 추가하였습니다. 해당 변수가 true가 되면 BossBT 클래스의 Update에서 확인 후 sturn 애니메이션을 출력하게 하였습니다.
4. Hit과 Sturn 상태의 초반 진행 상황이 비슷하여 해당 상황의 애니메이션 이름을 매개변수로 받는  BossBeingShot(string animationName) 함수를 추가하였습니다. 트래킹 및 걷기 상황을 False로 바꾸고 애니메이션을 플레이하게 하는 함수입니다.

## 추가사항
1. 보스의 인지 범위 관련하여 중첩되는 부분이 있는 것 같아 최적화를 진행 중입니다. 아직은 확인 중에 있으며 완성하는 대로 적용될 브랜치에 추가사항으로 작성하겠습니다.