### PR TITLE
MON-162-QuickSlot

### DIFF
--- a/Assets/Scenes/Player/PlayerProtoType.unity
+++ b/Assets/Scenes/Player/PlayerProtoType.unity
@@ -370,99 +370,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1001 &225691971
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 983852566087758812, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: _player
-      value: 
-      objectReference: {fileID: 2032744760}
-    - target: {fileID: 1550405990992263279, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3063201237040743895, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_TagString
-      value: Boss
-      objectReference: {fileID: 0}
-    - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -37.4
-      objectReference: {fileID: 0}
-    - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7800857922649941904, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_Name
-      value: Trex
-      objectReference: {fileID: 0}
-    - target: {fileID: 7800857922649941904, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7800857922649941904, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-        type: 3}
-      propertyPath: m_TagString
-      value: Untagged
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2c50569d6f59a0a40b46eb47c5ea7343, type: 3}
 --- !u!1 &481315360
 GameObject:
   m_ObjectHideFlags: 0
@@ -674,6 +581,53 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &870351756
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 870351758}
+  - component: {fileID: 870351757}
+  m_Layer: 0
+  m_Name: Cat
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &870351757
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 870351756}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 63fcd5106c5d9cf4ab762a242ea3c3f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  catCollider: {fileID: 0}
+  player: {fileID: 2032744760}
+  boss: {fileID: 1416441423}
+--- !u!4 &870351758
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 870351756}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -6.6986265, y: -0.8861839, z: 6.821545}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &914536016 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1994513090600075941, guid: f140e689e2a78d54e828536c733f1d4e,
@@ -852,7 +806,7 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
---- !u!1001 &1110694213
+--- !u!1001 &1133229901
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -860,26 +814,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 709087072548218683, guid: d01d8c04389269c4cb29628758ee35e3,
-        type: 3}
-      propertyPath: boss
-      value: 
-      objectReference: {fileID: 1868060611}
-    - target: {fileID: 709087072548218683, guid: d01d8c04389269c4cb29628758ee35e3,
-        type: 3}
-      propertyPath: player
-      value: 
-      objectReference: {fileID: 2032744760}
-    - target: {fileID: 2291671120546458638, guid: d01d8c04389269c4cb29628758ee35e3,
-        type: 3}
-      propertyPath: boss
-      value: 
-      objectReference: {fileID: 1868060611}
-    - target: {fileID: 2291671120546458638, guid: d01d8c04389269c4cb29628758ee35e3,
-        type: 3}
-      propertyPath: player
-      value: 
-      objectReference: {fileID: 2032744760}
     - target: {fileID: 4609498034922007123, guid: d01d8c04389269c4cb29628758ee35e3,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -933,7 +867,7 @@ PrefabInstance:
     - target: {fileID: 4764970317103825413, guid: d01d8c04389269c4cb29628758ee35e3,
         type: 3}
       propertyPath: m_Name
-      value: Cat
+      value: Cat (1)
       objectReference: {fileID: 0}
     - target: {fileID: 4764970317103825413, guid: d01d8c04389269c4cb29628758ee35e3,
         type: 3}
@@ -1105,12 +1039,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 156762429}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1868060611 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7424718759419919658, guid: 2c50569d6f59a0a40b46eb47c5ea7343,
-    type: 3}
-  m_PrefabInstance: {fileID: 225691971}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2032744760 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9055791104001212950, guid: f140e689e2a78d54e828536c733f1d4e,
@@ -1129,6 +1057,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 844514328b28ebf448123e8e89c7f317, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cat: {fileID: 870351757}
   cameraArm: {fileID: 98368798}
   weaponObj: {fileID: 156762430}
 --- !u!114 &2032744765
@@ -1158,7 +1087,7 @@ SceneRoots:
   - {fileID: 203844589}
   - {fileID: 559338942}
   - {fileID: 156762429}
-  - {fileID: 225691971}
-  - {fileID: 1110694213}
   - {fileID: 1416441423}
   - {fileID: 481315364}
+  - {fileID: 870351758}
+  - {fileID: 1133229901}

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -131,6 +132,12 @@ public class Player : Entity
         }
         currentHp -= damage;
 
+    }
+
+    public void Heal(int healingAmount)
+    {
+        currentHp += healingAmount;
+        currentHp = Math.Clamp(currentHp , 0 , maxHp);
     }
 
 

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -1,8 +1,11 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.Playables;
+
+
 
 public class PlayerController : Controller
 {
@@ -20,6 +23,8 @@ public class PlayerController : Controller
     }
 
     private Player player;
+    [SerializeField]  private Cat cat;
+
     private GreatSword greatSword;
     private float walkSpeed = 4f;
     private float runSpeed = 7f;
@@ -38,6 +43,16 @@ public class PlayerController : Controller
 
     public PlayerState playerState { get; private set; }
 
+    //½½·Ô
+    private Item_Potion potion;
+    private Skill_CatAttack catAttack;
+    private Skill_CatHeal catHeal;
+
+    //Äü½½·Ô
+    private Slot[] QuickSlot;
+    private int quickSlotIndex = 0;
+    private int quickSlotCount = 0;
+
     public void Start()
     {
         player = GetComponent<Player>();
@@ -45,7 +60,17 @@ public class PlayerController : Controller
         playerState = PlayerState.Idle;
         moveSpeed = walkSpeed;
         isRoll = false;
+        potion = new Item_Potion(player, 10, 10);
+        catAttack = new Skill_CatAttack(player, cat);
+        catHeal = new Skill_CatHeal(player, cat);
+        QuickSlot = new Slot[4];
+        QuickSlot[0] = potion;
+        QuickSlot[1] = catAttack;
+        QuickSlot[2] = catHeal;
+        quickSlotCount = 3;
     }
+
+
 
 
     public void Update()
@@ -53,6 +78,7 @@ public class PlayerController : Controller
         InputSend();
         player.GroundCheck();
         LookAround();
+        QuickSlotIndexChange();
     }
 
     public void InputSend()
@@ -92,6 +118,10 @@ public class PlayerController : Controller
             playerState = PlayerState.Walk;
             moveSpeed = walkSpeed;
             player.Move(moveSpeed, moveInput);
+        }
+        else if (Input.GetKeyDown(KeyCode.E))
+        {
+            QuickSlot[quickSlotIndex].Activate();
         }
         //Á¤Áö
         else
@@ -136,9 +166,7 @@ public class PlayerController : Controller
                 //playerState = PlayerState.Idle;
                 player.ApplyState();
             }
-
         }
-
     }
 
     private void LookAround()
@@ -159,4 +187,21 @@ public class PlayerController : Controller
 
         cameraArm.rotation = Quaternion.Euler(x, camAngle.y + mouseDelta.x, camAngle.z);
     }
+
+    private void QuickSlotIndexChange()
+    {
+        float scroll = Input.GetAxis("Mouse ScrollWheel");
+
+        if (scroll > 0f)
+        {
+            quickSlotIndex = (quickSlotIndex + 1) % (quickSlotCount);
+        }
+        else if(scroll < 0f)
+        {
+            quickSlotIndex = (quickSlotIndex + 1) % (quickSlotCount);
+        }
+        Debug.Log($"ÇöÀç Äü½½·Ô Index{quickSlotIndex}");
+    }
+
+
 }

--- a/Assets/Scripts/Player/PlayerWeapon/GreatSword.cs
+++ b/Assets/Scripts/Player/PlayerWeapon/GreatSword.cs
@@ -32,9 +32,6 @@ public class GreatSword : Weapon
         }
     }
 
-
-
-
     protected override void AppearHitEffect(Vector3 hitPos, float duration)
     {
         base.AppearHitEffect(hitPos, duration);

--- a/Assets/Scripts/Slot.meta
+++ b/Assets/Scripts/Slot.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e8e871ad9f559fa4cb4f996265e71a1a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Slot/Item_Potion.cs
+++ b/Assets/Scripts/Slot/Item_Potion.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Numerics;
+using UnityEngine;
+using static UnityEditor.Experimental.GraphView.GraphView;
+
+public class Item_Potion : Slot
+{
+    private Player player;
+    private int healingAmount;
+    public int count;
+    public Item_Potion(Player _player , int _healingAmount , int _count)
+    {
+        player = _player;
+        healingAmount = _healingAmount;
+        count = _count;
+    }
+
+    public override void Activate()
+    {
+        if(count > 0)
+        {
+            Debug.Log($"포션 사용 count: {count}");
+            Heal();
+            count--;
+        }
+    }
+
+    private void Heal()
+    {
+        player.Heal(healingAmount);
+    }
+
+}

--- a/Assets/Scripts/Slot/Item_Potion.cs.meta
+++ b/Assets/Scripts/Slot/Item_Potion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 869901b94bd058c4c90d7ecafcf19f1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Slot/Skill_CatAttack.cs
+++ b/Assets/Scripts/Slot/Skill_CatAttack.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Skill_CatAttack : Slot
+{
+    Cat cat;
+    public Skill_CatAttack(Cat _cat)
+    {
+        cat = _cat;
+    }
+
+    public override void Activate()
+    {
+        Debug.Log($"CatAttack");
+        CatAttack();
+    }
+
+    private void CatAttack()
+    {
+        //cat.SkillAttack(Transform monster);
+    }
+}
+
+

--- a/Assets/Scripts/Slot/Skill_CatAttack.cs.meta
+++ b/Assets/Scripts/Slot/Skill_CatAttack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1a1be247c76f8a4889839c6cae19501
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Slot/Skill_CatHeal.cs
+++ b/Assets/Scripts/Slot/Skill_CatHeal.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Skill_CatHeal : Slot
+{
+    private Cat cat;
+    public Skill_CatHeal(Cat _cat)
+    {
+        cat = _cat;
+    }
+
+    public override void Activate()
+    {
+        Debug.Log($"CatHeal");
+        CatHeal();
+    }
+
+    private void CatHeal()
+    {
+        //cat.Heal();
+    }
+
+}

--- a/Assets/Scripts/Slot/Skill_CatHeal.cs.meta
+++ b/Assets/Scripts/Slot/Skill_CatHeal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36c405da41c5de3478e09f626535d597
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Slot/Slot.cs
+++ b/Assets/Scripts/Slot/Slot.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+abstract public class Slot
+{
+    abstract public void Activate();
+}

--- a/Assets/Scripts/Slot/Slot.cs.meta
+++ b/Assets/Scripts/Slot/Slot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf7f95dd91aabde40bbd74ffc38374a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#설명
1. Slot.cs 추가 
 - Activate() : 슬롯이 수행할 행동을 담는 함수

2. Item_Potion.cs 추가 
 - player.Heal() 호출하여 Player의 currentHp 회복시킴

3. Skill_CatAttack.cs 추가 0
 - cat.SkillAttack(Transform monster) 호출하여 Cat에게 monster를 공격하게 함

4. Skill_CatHeal.cs 추가 
 - cat.Heal() 호출하여 Cat에게 Player를 회복시키게 함

5. PlayerController.cs 내용 추가 
- Slot[] QuickSlot 추가 
   - QuickSlot에 Item_Potion, Skill_CatAttack, Skill_CatHeal등 사용할 Slot들을 넣어줌 
   - 마우스 휠로 quickSlotIndex값 조정 
- E키 입력시 QuickSlot[quickSlotIndex].Activate() 실행

6. Player.cs 내용추가 
 - Heal()함수 추가: Player의 currentHp를 증가시킨다.