### PR TITLE
MON-157-Anjanath-Normal-States

### DIFF
--- a/Assets/Scenes/Boss/ProtoBossScene.unity
+++ b/Assets/Scenes/Boss/ProtoBossScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028331, g: 0.2257133, b: 0.3069217, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2379,6 +2379,7 @@ GameObject:
   - component: {fileID: 620319054}
   - component: {fileID: 620319053}
   - component: {fileID: 620319052}
+  - component: {fileID: 620319056}
   m_Layer: 0
   m_Name: AnjanathArrivalPos
   m_TagString: Finish
@@ -2467,11 +2468,23 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 30, y: 1, z: -23}
-  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &620319056
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620319051}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8f7873af98eed724e91cb4fa599f7d07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &961739749
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Boss/ProtoBossScene.unity
+++ b/Assets/Scenes/Boss/ProtoBossScene.unity
@@ -2135,7 +2135,7 @@ GameObject:
   - component: {fileID: 523728521}
   - component: {fileID: 523728526}
   m_Layer: 6
-  m_Name: GameObject
+  m_Name: Anjanath
   m_TagString: Boss
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2208,6 +2208,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c6f8deb367129245973965a6f71c559, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  targetPos: {x: 0, y: 0, z: 0}
+  isArrivalTargetPos: 1
+  isSetTargetPos: 0
+  arrivalPos: {fileID: 620319055}
   anjanathBT: {fileID: 523728523}
   DamageStack: 0
   playerTr: {fileID: 2032744760}
@@ -2360,6 +2364,111 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 30, y: 30, z: 30}
   m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &620319051
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 620319055}
+  - component: {fileID: 620319054}
+  - component: {fileID: 620319053}
+  - component: {fileID: 620319052}
+  m_Layer: 0
+  m_Name: AnjanathArrivalPos
+  m_TagString: Finish
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &620319052
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620319051}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &620319053
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620319051}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &620319054
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620319051}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &620319055
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 620319051}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 30, y: 1, z: -23}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5347,3 +5456,4 @@ SceneRoots:
   - {fileID: 156762429}
   - {fileID: 1110694213}
   - {fileID: 523728525}
+  - {fileID: 620319055}

--- a/Assets/Scenes/Boss/ProtoBossScene.unity
+++ b/Assets/Scenes/Boss/ProtoBossScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028331, g: 0.2257133, b: 0.3069217, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2379,7 +2379,6 @@ GameObject:
   - component: {fileID: 620319054}
   - component: {fileID: 620319053}
   - component: {fileID: 620319052}
-  - component: {fileID: 620319056}
   m_Layer: 0
   m_Name: AnjanathArrivalPos
   m_TagString: Finish
@@ -2473,18 +2472,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &620319056
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 620319051}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f7873af98eed724e91cb4fa599f7d07, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &961739749
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Boss/Anjanath.cs
+++ b/Assets/Scripts/Boss/Anjanath.cs
@@ -174,6 +174,14 @@ public class Anjanath : Monster
         }
     }
 
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Finish"))
+        {
+            isArrivalTargetPos = true;
+        }
+    }
+
     private void OnTriggerStay(Collider other)
     {
         if (isBossRecognized)
@@ -183,14 +191,17 @@ public class Anjanath : Monster
 
         else if (!isBossRecognized)
         {
-            perceptionTime += Time.deltaTime;
-            if (perceptionTime >= 2f)
+            if (other.CompareTag("Player"))
             {
-                perceptionTime = 0;
-                if (other.CompareTag("Player"))
+                perceptionTime += Time.deltaTime;
+
+                if (perceptionTime >= 2f)
                 {
-                    isBossRecognized = true;
-                    targetTr = playerTr;
+                    perceptionTime = 0;
+                    {
+                        isBossRecognized = true;
+                        targetTr = playerTr;
+                    }
                 }
             }
         }

--- a/Assets/Scripts/Boss/Anjanath.cs
+++ b/Assets/Scripts/Boss/Anjanath.cs
@@ -159,12 +159,7 @@ public class Anjanath : Monster
 
         else if (!isBossRecognized)
         {
-            if (SetChance())
-                anjanathBT.anjanathState = State.Walk;
-
-            else
-                anjanathBT.anjanathState = State.Idle;
-
+            anjanathBT.anjanathState = State.Idle;
         }
     }
 

--- a/Assets/Scripts/Boss/AnjanathBT.cs
+++ b/Assets/Scripts/Boss/AnjanathBT.cs
@@ -52,7 +52,7 @@ public class AnjanathBT : BossBehaviorTree
 
                 // Right SubTree
                 .Selector()
-                    .Condition("IsNomalStates", () => anjanathState == State.Idle)
+                    //.Condition("IsNomalStates", () => anjanathState == State.Idle)
                     .Sequence()
                         .Condition("IsTargetSelected", () => anjanath.isSetTargetPos)
                         .Do("NomalWalking", () =>

--- a/Assets/Scripts/Boss/AnjanathBT.cs
+++ b/Assets/Scripts/Boss/AnjanathBT.cs
@@ -52,16 +52,16 @@ public class AnjanathBT : BossBehaviorTree
 
                 // Right SubTree
                 .Selector()
+                    .Condition("IsNomalStates", () => anjanathState == State.Idle)
                     .Sequence()
-                        .Condition("ChanceForWalking", () => anjanathState == State.Walk)
-                            .Do("NomalWalking", () =>
-                            {
-                                anjanath.NormalMoving(2);
-                                return TaskStatus.Success;
-                            })
+                        .Condition("IsTargetSelected", () => anjanath.isSetTargetPos)
+                        .Do("NomalWalking", () =>
+                        {
+                            anjanath.NormalMoving(2);
+                            return TaskStatus.Success;
+                        })
                     .End()
                     .Sequence()
-                        .Condition("ChanceForWalking", () => anjanathState == State.Idle)
                         .Do(() =>
                         {
                             anjanath.Idle();

--- a/Assets/Scripts/Boss/Monster.cs
+++ b/Assets/Scripts/Boss/Monster.cs
@@ -6,10 +6,13 @@ using UnityEngine.EventSystems;
 public class Monster : Entity
 {
     public int grade { get; set; }
-    protected Vector3 targetPos;
+    public Vector3 targetPos;
     protected int rotationSpeed;
     protected bool canAttack;
     protected bool setHit;
+    public bool isArrivalTargetPos;
+    public bool isSetTargetPos;
+    public Transform arrivalPos;
 
     public override int Attack()
     {
@@ -55,19 +58,32 @@ public class Monster : Entity
 
     virtual public void Idle()
     {
+        Debug.Log("13456432345321345");
+
         animator.Play("Idle");
-        targetPos = SetRandomPos();
+
+        if (isArrivalTargetPos)
+        {
+            arrivalPos.position = SetRandomPos();
+            isSetTargetPos = true;
+            isArrivalTargetPos = false;
+        }
     }
 
     virtual public void NormalMoving(float moveSpeed)
     {
         animator.Play("NormalWalking");
         // GroundCheck
-        Move(moveSpeed, targetPos);
+        Move(moveSpeed, arrivalPos.position);
+
+        if (!isArrivalTargetPos)
+        {
+            isSetTargetPos = false;
+        }
     }
     
     public void TrackingPlayer(Transform targetTr)
-    { 
+    {
         AnimatorStateInfo stateInfo = animator.GetCurrentAnimatorStateInfo(0);
 
         if (stateInfo.IsName("NormalAttack") && stateInfo.normalizedTime < 1.0f)

--- a/Assets/Scripts/Boss/Monster.cs
+++ b/Assets/Scripts/Boss/Monster.cs
@@ -32,8 +32,8 @@ public class Monster : Entity
 
     public Vector3 SetRandomPos()
     {
-        float targetX = Random.Range(140, 140);
-        float targetZ = Random.Range(140, 140);
+        float targetX = Random.Range(-140, 140);
+        float targetZ = Random.Range(-140, 140);
         return new Vector3(targetX, transform.position.y, targetZ);
     }
 

--- a/Assets/Scripts/Boss/Monster.cs
+++ b/Assets/Scripts/Boss/Monster.cs
@@ -32,8 +32,8 @@ public class Monster : Entity
 
     public Vector3 SetRandomPos()
     {
-        float targetX = Random.Range(transform.position.x - 100, transform.position.x + 100);
-        float targetZ = Random.Range(transform.position.z - 100, transform.position.z + 100);
+        float targetX = Random.Range(140, 140);
+        float targetZ = Random.Range(140, 140);
         return new Vector3(targetX, transform.position.y, targetZ);
     }
 
@@ -58,8 +58,6 @@ public class Monster : Entity
 
     virtual public void Idle()
     {
-        Debug.Log("13456432345321345");
-
         animator.Play("Idle");
 
         if (isArrivalTargetPos)
@@ -72,11 +70,19 @@ public class Monster : Entity
 
     virtual public void NormalMoving(float moveSpeed)
     {
+        AnimatorStateInfo stateInfo = animator.GetCurrentAnimatorStateInfo(0);
+
+        if (stateInfo.IsName("Idle") && stateInfo.normalizedTime < 1.0f)
+        {
+            return;
+        }
+
+
         animator.Play("NormalWalking");
         // GroundCheck
         Move(moveSpeed, arrivalPos.position);
 
-        if (!isArrivalTargetPos)
+        if (isArrivalTargetPos)
         {
             isSetTargetPos = false;
         }

--- a/Assets/Scripts/Boss/Proto/BossBT.cs
+++ b/Assets/Scripts/Boss/Proto/BossBT.cs
@@ -89,13 +89,14 @@ public class BossBT : MonoBehaviour
                 .Selector()
                     .Sequence()
                         .Condition("ChanceForWalking", () => SetNomalWalkingChance())
-                        .StateAction("NomalWalking", () => 
+                        .StateAction("NormalWalking", () => 
                         {
+                            Debug.Log("normalWalking");
                             _trackingPlayer = false;
                             _randomPosToWalk = RandomPosForWalking();
                             _canNomalWalking = true;
                         })
-                        .Do("NomalWalking", () =>
+                        .Do("NormalWalking", () =>
                         {
                             _canNomalWalking = false;
                             return TaskStatus.Success;
@@ -103,6 +104,7 @@ public class BossBT : MonoBehaviour
                     .End()
                     .StateAction("Idle", () =>
                     {
+                        Debug.Log("Idle");
                         _trackingPlayer = false;
                     })
                     .Do(() =>


### PR DESCRIPTION
## 설명

0. 해당 내용은 ProtoBossScene에서 구현하였습니다.

1. 보스가 플레이어를 공격하지도, 인식하지도 않는 상태에서 맵을 배회하고 있는 상황을 구현하였습니다.

2. 현재 맵이 x축과 축의 길이가 300인 정사각형이므로, 해당 구역 내에 있는 랜덤한 위치를 선정하여 해당 위치에 도착할 때까지 NormalWalk 애니메이션과 함께 걸은 후에 도착하면 Idle 애니메이션을 끝까지 출력 후 또다른 타겟 지점을 정하고 앞선 상황을 반복하도록 했습니다.

3. 이에 따라 보스의 도착 지점을 나타내는 AnjanathArrivalPos 오브젝트를 미리 생성 또는 인스턴스 생성할 필요성이 있습니다. 현재는 미리 Hierachy에 생성한 오브젝트를 통하여 해당 내용을 구현하였습니다.

4. 해당 상황 중간에 공격 또는 트래킹으로의 상태 전환에 대하여 정상 작동 확인하였습니다.